### PR TITLE
Correct the Twisted example in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Let's send 100 concurrent requests! \\o/
 	from twisted.internet.task import react
 	from requests_threads import AsyncSession
 	
-	session = requests.AsyncSession(n=100)
+	session = AsyncSession(n=100)
 
 	@inlineCallbacks
 	def main(reactor):


### PR DESCRIPTION
Hi Kenneth,

Awesome work, as ever. 

This is just a slight correction to help people with the Twisted example in the README. As far as I can see, the `AsyncSession` is already imported in to the namespace and not available on the `requests` object (yet? 😃 ).

Thanks!